### PR TITLE
Переписал block.parse_body

### DIFF
--- a/lib/http_block.js
+++ b/lib/http_block.js
@@ -128,27 +128,19 @@ class HttpBlock extends Block {
             headers = error.headers;
         }
 
-        let is_json = block.is_json;
-        if ( !is_json && headers ) {
-            const content_type = headers[ 'content-type' ];
-            if ( content_type ) {
-                is_json = rx_is_json.test( content_type );
-            }
-        }
-
         if ( error ) {
             if ( error.body ) {
-                if ( is_json ) {
+                const result = { body: error.body, headers: headers };
+                if ( typeof block.parse_body === 'function' ) {
                     try {
-                        error.body = JSON.parse( error.body );
+                        error.body = block.parse_body( result, context );
 
                     } catch ( e ) {
-                        //  Do nothing.
+                        //  Do nothing
                     }
-                }
 
-                if ( Buffer.isBuffer( error.body ) ) {
-                    error.body = error.body.toString();
+                } else {
+                    error.body = this._parse_error_body( result );
                 }
             }
 
@@ -160,26 +152,16 @@ class HttpBlock extends Block {
             body = null;
 
         } else {
-            if ( is_json ) {
+            if ( typeof block.parse_body === 'function' ) {
                 try {
-                    body = JSON.parse( result.body );
+                    body = block.parse_body( result, context );
 
                 } catch ( e ) {
-                    throw create_error( e, ERROR_ID.INVALID_JSON );
+                    throw create_error( e, ERROR_ID.PARSE_BODY_ERROR );
                 }
 
             } else {
-                if ( typeof block.parse_body === 'function' ) {
-                    try {
-                        body = block.parse_body( result, context );
-
-                    } catch ( e ) {
-                        throw create_error( e, ERROR_ID.PARSE_BODY_ERROR );
-                    }
-
-                } else {
-                    body = String( result.body );
-                }
+                body = this._parse_body( result );
             }
         }
 
@@ -191,6 +173,49 @@ class HttpBlock extends Block {
         };
     }
 
+    _parse_body( { body, headers } ) {
+        const is_json = this._is_json_response( headers );
+        if ( is_json ) {
+            try {
+                return JSON.parse( body );
+
+            } catch ( e ) {
+                throw create_error( e, ERROR_ID.INVALID_JSON );
+            }
+        }
+
+        return String( body );
+    }
+
+    _parse_error_body( { body, headers } ) {
+        const is_json = this._is_json_response( headers );
+        if ( is_json ) {
+            try {
+                return JSON.parse( body );
+
+            } catch ( e ) {
+                //  Do nothing.
+            }
+        }
+
+        if ( Buffer.isBuffer( body ) ) {
+            return body.toString();
+        }
+
+        return body;
+    }
+
+    _is_json_response( headers ) {
+        let is_json = this._block.is_json;
+        if ( !is_json && headers ) {
+            const content_type = headers[ 'content-type' ];
+            if ( content_type ) {
+                is_json = rx_is_json.test( content_type );
+            }
+        }
+
+        return is_json;
+    }
 }
 
 //  ---------------------------------------------------------------------------------------------------------------  //

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -244,7 +244,7 @@ interface DescriptHttpBlockDescription< Params, Context > {
     retry_timeout?: number;
 
     prepare_request_options?: ( options: HttpsRequestOptions ) => HttpsRequestOptions;
-    parse_body?: (result: DescriptHttpResult, context: Context) => {};
+    parse_body?: (result: { headers: Record< string, string >; body: Buffer }, context: Context) => {};
 
     family?: DescriptHttpBlockDescriptionCallback< number, Params, Context >;
 

--- a/tests/http_block.test.js
+++ b/tests/http_block.test.js
@@ -1234,6 +1234,41 @@ describe( 'http', () => {
             expect( a_context ).toBe( context );
         } );
 
+        it( 'custom parse_body for error', async () => {
+            const path = get_path();
+
+            const CONTENT = 'Привет!';
+
+            fake.add( path, {
+                status_code: 500,
+                content: CONTENT,
+            } );
+
+            const BODY = 'Пока!';
+            const spy = jest.fn( () => {
+                return BODY;
+            } );
+
+            const block = base_block( {
+                block: {
+                    pathname: path,
+                    parse_body: spy,
+                },
+            } );
+
+            expect.assertions( 3 );
+
+            const context = {};
+            try {
+                await de.run( block, { context } );
+            } catch ( e ) {
+                const [ a_result, a_context ] = spy.mock.calls[ 0 ];
+                expect( e.error.body ).toBe( BODY );
+                expect( Buffer.compare( a_result.body, Buffer.from( CONTENT ) ) ).toBe( 0 );
+                expect( a_context ).toBe( context );
+            }
+        } );
+
     } );
 
 } );


### PR DESCRIPTION
Если у блока есть parse_body, то парсинг тела ответа всегда проходит через нее. Если нет, то через дефолтный.

Fix #5